### PR TITLE
Converts "nwa" to んわ instead of ぬぁ, removes some warnings from code

### DIFF
--- a/WaniKani/res/layout/card_available.xml
+++ b/WaniKani/res/layout/card_available.xml
@@ -38,19 +38,6 @@
                     android:id="@+id/card_available_lessons"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="0"
-                    android:textAppearance="@android:style/TextAppearance.Medium"
-                    android:textColor="@color/text_gray" />
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text=" "
-                    android:textAppearance="@android:style/TextAppearance.Medium" />
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
                     android:text="@string/card_content_available_lessons_capital"
                     android:textAppearance="@android:style/TextAppearance.Medium"
                     android:textColor="@color/text_gray" />
@@ -66,19 +53,6 @@
 
                 <TextView
                     android:id="@+id/card_available_reviews"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="0"
-                    android:textAppearance="@android:style/TextAppearance.Medium"
-                    android:textColor="@color/text_gray" />
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text=" "
-                    android:textAppearance="@android:style/TextAppearance.Medium" />
-
-                <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/card_content_available_reviews_capital"

--- a/WaniKani/res/values/strings.xml
+++ b/WaniKani/res/values/strings.xml
@@ -53,6 +53,15 @@
     <string name="card_title_critical_items">Critical Items</string>
 
     <!-- Card Content (Available) Strings -->
+    <plurals name="card_content_available_lessons_capital">
+        <item quantity="one">%d LESSON</item>
+        <item quantity="other">%d LESSONS</item>
+    </plurals>
+
+    <plurals name="card_content_available_reviews_capital">
+        <item quantity="one">%d REVIEW</item>
+        <item quantity="other">%d REVIEWS</item>
+    </plurals>
     <string name="card_content_available_lessons">Lessons</string>
     <string name="card_content_available_lessons_capital">LESSONS</string>
     <string name="card_content_available_reviews">Reviews</string>

--- a/WaniKani/src/tr/xip/wanikani/JapaneseIME.java
+++ b/WaniKani/src/tr/xip/wanikani/JapaneseIME.java
@@ -44,7 +44,7 @@ public class JapaneseIME {
 
     public JapaneseIME ()
     {
-        map = new Hashtable<String, String> ();
+        map = new Hashtable<> ();
 
         populateTable ();
     }
@@ -105,7 +105,7 @@ public class JapaneseIME {
         s = s.substring (i, pos);
         xlated = parse (s);
 
-        return s != xlated ? new Replacement (i, pos, xlated) : null;
+        return !(s.equals(xlated)) ? new Replacement (i, pos, xlated) : null;
     }
 
     private void populateTable ()

--- a/WaniKani/src/tr/xip/wanikani/JapaneseIME.java
+++ b/WaniKani/src/tr/xip/wanikani/JapaneseIME.java
@@ -292,7 +292,7 @@ public class JapaneseIME {
         ja = s [s.length - 1];
         for (i = 0; i < s.length - 1; i++) {
             put (s [i] + "u", ja);
-            put (s [i] + "wa", ja + "ぁ");
+            if (!s[i].equals("n")) put (s [i] + "wa", ja + "ぁ"); // ensures "nwa" outputs as "んわ"
         }
     }
 

--- a/WaniKani/src/tr/xip/wanikani/app/fragment/card/AvailableCard.java
+++ b/WaniKani/src/tr/xip/wanikani/app/fragment/card/AvailableCard.java
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.res.Resources;
 import android.graphics.PorterDuff;
 import android.net.Uri;
 import android.os.Bundle;
@@ -126,8 +127,11 @@ public class AvailableCard extends Fragment implements StudyQueueGetTaskCallback
     public void onStudyQueueGetTaskPostExecute(StudyQueue queue) {
         if (queue != null && queue.getUserInfo() != null) {
             if (!queue.getUserInfo().isVacationModeActive()) {
-                mLessonsAvailable.setText(queue.getAvailableLesonsCount() + "");
-                mReviewsAvailable.setText(queue.getAvailableReviewsCount() + "");
+                int lessonsAvailable = queue.getAvailableLesonsCount();
+                int reviewsAvailable = queue.getAvailableReviewsCount();
+                Resources res = getResources();
+                mLessonsAvailable.setText(res.getQuantityString(R.plurals.card_content_available_lessons_capital, lessonsAvailable, lessonsAvailable));
+                mReviewsAvailable.setText(res.getQuantityString(R.plurals.card_content_available_reviews_capital, reviewsAvailable, reviewsAvailable));
 
                 mListener.onAvailableCardSyncFinishedListener(DashboardFragment.SYNC_RESULT_SUCCESS);
             } else


### PR DESCRIPTION
This makes it so that users who use this app won't type in "denwa" for 電話 and be confused as to how they somehow typed in でぬぁ instead of でんわ.