### PR TITLE
Usability improvements (lesson quit warn dialog, keep screen awake, default single mode, etc)

### DIFF
--- a/WaniKani/build.gradle
+++ b/WaniKani/build.gradle
@@ -8,17 +8,17 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha2'
+        classpath 'com.android.tools.build:gradle:2.0.0'
     }
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '23.0.2'
+    compileSdkVersion 24
+    buildToolsVersion '24.0.0'
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 23
+        targetSdkVersion 24
         versionCode 10
         versionName "1.2.1"
     }

--- a/WaniKani/res/layout/fragment_dashboard.xml
+++ b/WaniKani/res/layout/fragment_dashboard.xml
@@ -98,6 +98,22 @@
                     </android.support.v7.widget.CardView>
 
                     <android.support.v7.widget.CardView
+                        android:id="@+id/fragment_dashboard_progress_holder"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="@dimen/margin_card_between"
+                        android:layout_marginLeft="@dimen/margin_card_side"
+                        android:layout_marginRight="@dimen/margin_card_side"
+                        android:foreground="@drawable/selector_background_neutral">
+
+                        <FrameLayout
+                            android:id="@+id/fragment_dashboard_progress_card"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layoutAnimation="@anim/fade_controller" />
+                    </android.support.v7.widget.CardView>
+
+                    <android.support.v7.widget.CardView
                         android:id="@+id/fragment_dashboard_reviews_holder"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
@@ -128,22 +144,6 @@
 
                         <FrameLayout
                             android:id="@+id/fragment_dashboard_status_card"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layoutAnimation="@anim/fade_controller" />
-                    </android.support.v7.widget.CardView>
-
-                    <android.support.v7.widget.CardView
-                        android:id="@+id/fragment_dashboard_progress_holder"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="@dimen/margin_card_between"
-                        android:layout_marginLeft="@dimen/margin_card_side"
-                        android:layout_marginRight="@dimen/margin_card_side"
-                        android:foreground="@drawable/selector_background_neutral">
-
-                        <FrameLayout
-                            android:id="@+id/fragment_dashboard_progress_card"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:layoutAnimation="@anim/fade_controller" />

--- a/WaniKani/src/tr/xip/wanikani/LocalIMEKeyboard.java
+++ b/WaniKani/src/tr/xip/wanikani/LocalIMEKeyboard.java
@@ -125,7 +125,7 @@ public class LocalIMEKeyboard implements Keyboard {
         boolean translate;
 
         /// The list of chars are not allowed when entering a meaning
-        private static final String M_BANNED_CHARS = ",/;[]\\`\"=+";
+        private static final String M_BANNED_CHARS = ",/;[]\\`\"=+.?!";
 
         /// The list of chars are not allowed when entering a reading
         private static final String R_BANNED_CHARS = M_BANNED_CHARS + " ";

--- a/WaniKani/src/tr/xip/wanikani/LocalIMEKeyboard.java
+++ b/WaniKani/src/tr/xip/wanikani/LocalIMEKeyboard.java
@@ -163,6 +163,14 @@ public class LocalIMEKeyboard implements Keyboard {
                 return;
             }
 
+            // Aralox: Pressing backspace after a wrong answer will trigger the 'ignore' button.
+            if (canIgnore && et.length() < previousLength) {
+                ignore();
+                if (et.length() <= 0)   // Have at least one character so we can easily move to next Q.
+                    et.append(previousLastCharacter);
+                return;
+            }
+
             if (!translate)
                 return;
 
@@ -172,11 +180,19 @@ public class LocalIMEKeyboard implements Keyboard {
                 et.replace (repl.start, repl.end, repl.text);
         }
 
+        //Aralox: used for checking backspace press (used to trigger 'ignore' button).
+        int previousLength;
+        char previousLastCharacter = ' ';
+
         @Override
         public void beforeTextChanged (CharSequence cs, int start, int count, int after)
         {
-	    	/* empty */
+            //Aralox: used for checking backspace press (used to trigger 'ignore' button).
+	    	previousLength = cs.length();
+            if (previousLength > 0)
+                previousLastCharacter = cs.charAt(previousLength-1);
         }
+
 
         @Override
         public void onTextChanged (CharSequence cs, int start, int before, int count)


### PR DESCRIPTION
Hi İhsan, 
I've incorporated a few usability changes which makes the app a little more pleasant/efficient for me, and thought I'd share them. This is my first time forking and creating a pull request, so apologies if I screwed something up. 

Here is a copy of my commit message:
- Default 'single' mode selected.
- Keep screen on during lessons and reviews.
- Confirmation dialog if back button pressed during lessons.
- Added ".?!" to banned characters in meaning textbox.
- Rearranged dashboard, moved progress card up (so overall lesson progress can be seen without scrolling).
- Updated build.gradle SDK version and tools from 23 to 24
- Changed gradle version from 2.2.0-alpha2 to 2.0.0, because builds with the alpha version crashed for me.

An issue I would also really like to fix but cannot figure out how:
- When I click on the 'notes' box in lessons/reviews, the internal browser resizes after the keyboard appears, causing the keyboard to disappear again. This makes it impossible to edit notes.

Please let me know if you have any ideas on how to approach that problem.

I know the situation is pretty bad over in Turkey right now (I'm in Australia), so don't stress about replying to this any time soon. I hope you and your family are alright. 

Love, 
Aralox