### PR TITLE
Prevent activity restart when an external keyboard is connected

### DIFF
--- a/WaniKani/AndroidManifest.xml
+++ b/WaniKani/AndroidManifest.xml
@@ -67,7 +67,7 @@
 
         <activity
             android:name=".app.activity.WebReviewActivity"
-            android:configChanges="orientation|keyboardHidden|screenSize"
+            android:configChanges="orientation|keyboardHidden|screenSize|keyboard"
             android:hardwareAccelerated="true"
             android:launchMode="singleTop"
             android:parentActivityName=".app.activity.MainActivity"
@@ -82,7 +82,7 @@
 
         <activity
             android:name=".app.activity.SWWebReviewActivity"
-            android:configChanges="orientation|keyboardHidden|screenSize"
+            android:configChanges="orientation|keyboardHidden|screenSize|keyboard"
             android:hardwareAccelerated="false"
             android:launchMode="singleTop"
             android:parentActivityName=".app.activity.MainActivity"


### PR DESCRIPTION
Plugging in an external (bluetooth or USB) keyboard used to restart the whole review and lesson views. This will allow the reviews and lessons to continue when plugging or unplugging external keyboards.